### PR TITLE
Gamma, factorial (postfix !), sinc, and coth

### DIFF
--- a/lib/defs.test.ts
+++ b/lib/defs.test.ts
@@ -7,7 +7,7 @@ import {
   resolveExpr,
   scanDefinition,
 } from './defs.ts';
-import { evaluate, parseExpr } from './expr.ts';
+import { evaluate, gammaFn, parseExpr } from './expr.ts';
 import { toGLSL } from './glsl.ts';
 import { classify } from './plot.ts';
 
@@ -26,6 +26,16 @@ describe('scanDefinition', () => {
     expect(scanDefinition('sin(x) = 1')).toBeNull(); // built-in
     expect(scanDefinition('x^2 + y^2 = 4')).toBeNull();
     expect(scanDefinition('e = 3')).toBeNull();
+  });
+
+  it('lets a definition shadow a late-addition builtin', () => {
+    // Graphs saved before gamma/sinc/… existed may define these names.
+    expect(scanDefinition('gamma(x) = 1/sqrt(1-x^2)')).toMatchObject({ kind: 'fn', name: 'gamma' });
+    expect(scanDefinition('sinc = 0.5')).toMatchObject({ kind: 'const', name: 'sinc' });
+    const { defs, errors } = buildDefs([{ kind: 'fn', name: 'gamma', params: ['x'], rhs: '2x' }]);
+    expect(errors.size).toBe(0);
+    const e = resolveExpr(parseExpr('gamma(3) + 1', new Set(['gamma'])), n => defs.fns.get(n));
+    expect(evaluate(e, {})).toBe(7); // the user's 2x, not Γ(3) + 1 = 3
   });
 });
 
@@ -55,6 +65,13 @@ describe('d/dx derivative syntax', () => {
 
   it('nests', () => {
     expect(at('d/dx (d/dx (x^3))', { x: 2 })).toBe(12);
+  });
+
+  it('falls back to finite differences where diff() has no answer', () => {
+    const fd = (f: (x: number) => number, x: number) => (f(x + 1e-4) - f(x - 1e-4)) / 2e-4;
+    expect(at('d/dx (x!)', { x: 4 })).toBeCloseTo(fd(x => gammaFn(x + 1), 4), 10);
+    expect(at('d/dx gamma(x)', { x: 4 })).toBeCloseTo(fd(gammaFn, 4), 10);
+    expect(at('d/dx floor(x)', { x: 0.5 })).toBe(0);
   });
 });
 

--- a/lib/defs.ts
+++ b/lib/defs.ts
@@ -20,8 +20,8 @@
  *   otherwise by expanding a fixed Gauss–Legendre sum the same way Σ
  *   expands — so every downstream consumer still sees ordinary expressions.
  */
-import { add, diff, div, mul, neg, pow, sub } from './diff.ts';
-import { FUNCTIONS, type Expr, evaluate, freeVars, parseExpr, substVars } from './expr.ts';
+import { NonSmoothError, add, diff, div, mul, neg, pow, sub } from './diff.ts';
+import { FUNCTIONS, SHADOWABLE_FNS, type Expr, evaluate, freeVars, parseExpr, substVars } from './expr.ts';
 import { QUAD_TERMS, antiderivative, improperSum, quadratureSum, verifyDefinite } from './integrate.ts';
 import { lowerGeom, pointComps, vecStateComps } from './geom.ts';
 import { type Mat, matrixFromList } from './mat.ts';
@@ -117,8 +117,10 @@ const CONST_RE = /^\s*([A-Za-z_]\w*)\s*=(?!=)([\s\S]+)$/;
 const STATE_RE = /^\s*([A-Za-z_]\w*)'\s*=(?!=)([\s\S]+)$/;
 const INIT_RE = /^\s*([A-Za-z_]\w*)\s*\(\s*0\s*\)\s*=(?!=)([\s\S]+)$/;
 
-/** A name a definition may claim: not a builtin, not reserved, not a uniform. */
-const nameable = (n: string): boolean => !FUNCTIONS.has(n) && !RESERVED.has(n) && !n.startsWith('u_');
+/** A name a definition may claim: not a builtin (except the late-addition
+ *  ones old graphs may define themselves), not reserved, not a uniform. */
+export const nameable = (n: string): boolean =>
+  (!FUNCTIONS.has(n) || SHADOWABLE_FNS.has(n)) && !RESERVED.has(n) && !n.startsWith('u_');
 
 /** Detect a definition row before parsing (so calls to it parse everywhere). */
 export function scanDefinition(text: string): Definition | null {
@@ -175,8 +177,25 @@ function numeratorWrap(n: Expr): { order: number; wrap: (x: Expr) => Expr } | nu
   return null;
 }
 
+/** Step for the central-difference fallback. Balances truncation against
+ *  float32 roundoff — plots evaluate the expanded expression on the GPU. */
+const FD_H = 1e-4;
+
 function applyDiff(e: Expr, v: string, order: number): Expr {
-  for (let k = 0; k < order; k++) e = diff(e, v);
+  for (let k = 0; k < order; k++) {
+    try {
+      e = diff(e, v);
+    } catch (err) {
+      if (!(err instanceof NonSmoothError)) throw err;
+      // factorial, gamma, floor, …: expand a symbolic central difference,
+      // the fallback roots.ts and the renderer's normals use when diff() throws.
+      const vv: Expr = { kind: 'var', name: v };
+      e = div(
+        sub(substVars(e, { [v]: add(vv, num(FD_H)) }), substVars(e, { [v]: sub(vv, num(FD_H)) })),
+        num(2 * FD_H),
+      );
+    }
+  }
   return e;
 }
 

--- a/lib/diff.test.ts
+++ b/lib/diff.test.ts
@@ -38,6 +38,13 @@ describe('diff', () => {
     expect(ddx('|x^2-1|', { x: 0.5 })).toBe(-1); // sign(x^2-1)*2x = -1
   });
 
+  it('differentiates sinc, including the removable hole at 0', () => {
+    const fd = (f: (x: number) => number, x: number) => (f(x + 1e-6) - f(x - 1e-6)) / 2e-6;
+    expect(ddx('sinc(x)', { x: 0 })).toBe(0);
+    expect(ddx('sinc(x)', { x: 2 })).toBeCloseTo(fd(x => Math.sin(x) / x, 2));
+    expect(ddx('sinc(x)', { x: -0.7 })).toBeCloseTo(fd(x => Math.sin(x) / x, -0.7));
+  });
+
   it('throws for non-smooth functions', () => {
     expect(() => diff(parseExpr('min(x, 1)'), 'x')).toThrow(/differentiate/);
     expect(() => diff(parseExpr('floor(x)'), 'x')).toThrow(/differentiate/);

--- a/lib/diff.ts
+++ b/lib/diff.ts
@@ -56,6 +56,10 @@ export function pow(a: Expr, b: Expr): Expr {
 
 const call = (name: string, ...args: Expr[]): Expr => ({ kind: 'call', name, args });
 
+/** A function with no usable symbolic derivative: callers may fall back to
+ *  finite differences (unlike other diff() errors, which are real errors). */
+export class NonSmoothError extends Error {}
+
 /** d(e)/d(v). Throws for functions without a usable derivative. */
 export function diff(e: Expr, v: string): Expr {
   switch (e.kind) {
@@ -102,7 +106,7 @@ export function diff(e: Expr, v: string): Expr {
         // φ′ = φ·(−z·z′ − s′/s): the −z z′ from the exponent, −s′/s from 1/s.
         return mul(pdf, sub(mul(neg(z), dz), div(diff(s, v), s)));
       }
-      if (e.args.length !== 1) throw new Error(`Cannot differentiate ${e.name}.`);
+      if (e.args.length !== 1) throw new NonSmoothError(`Cannot differentiate ${e.name}.`);
       const a = e.args[0];
       const da = diff(a, v);
       const chain = (outer: Expr) => mul(outer, da);
@@ -126,14 +130,23 @@ export function diff(e: Expr, v: string): Expr {
         case 'sqrt': return div(da, mul(num(2), call('sqrt', a)));
         case 'abs': return chain(call('sign', a));
         case 'erf': return chain(mul(num(2 / Math.sqrt(Math.PI)), call('exp', neg(pow(a, num(2))))));
-        // The removable hole at 0 stays: the expression is pointwise NaN
-        // there, one sample out of a whole curve.
-        case 'sinc': return chain(sub(div(call('cos', a), a), div(call('sin', a), pow(a, num(2)))));
+        case 'sinc':
+          // (cos x − sinc x)/x away from 0 — this form cancels less than
+          // cos/x − sin/x² — and the removable hole filled in: sinc is
+          // differentiable at 0 with derivative 0.
+          return chain({
+            kind: 'piecewise',
+            cases: [{
+              cond: { kind: 'ineq', op: '>', l: call('abs', a), r: ZERO },
+              value: div(sub(call('cos', a), call('sinc', a)), a),
+            }],
+            otherwise: ZERO,
+          });
         case 'coth': return chain(sub(ONE, pow(call('coth', a), num(2))));
         default:
           // min/max/floor/mod/… (and gamma: digamma isn't in the language):
           // no smooth derivative; caller falls back to FD.
-          throw new Error(`Cannot differentiate ${e.name}.`);
+          throw new NonSmoothError(`Cannot differentiate ${e.name}.`);
       }
     }
     case 'eq': return sub(diff(e.l, v), diff(e.r, v));

--- a/lib/diff.ts
+++ b/lib/diff.ts
@@ -126,8 +126,13 @@ export function diff(e: Expr, v: string): Expr {
         case 'sqrt': return div(da, mul(num(2), call('sqrt', a)));
         case 'abs': return chain(call('sign', a));
         case 'erf': return chain(mul(num(2 / Math.sqrt(Math.PI)), call('exp', neg(pow(a, num(2))))));
+        // The removable hole at 0 stays: the expression is pointwise NaN
+        // there, one sample out of a whole curve.
+        case 'sinc': return chain(sub(div(call('cos', a), a), div(call('sin', a), pow(a, num(2)))));
+        case 'coth': return chain(sub(ONE, pow(call('coth', a), num(2))));
         default:
-          // min/max/floor/mod/…: no smooth derivative; caller falls back to FD.
+          // min/max/floor/mod/… (and gamma: digamma isn't in the language):
+          // no smooth derivative; caller falls back to FD.
           throw new Error(`Cannot differentiate ${e.name}.`);
       }
     }

--- a/lib/dist.ts
+++ b/lib/dist.ts
@@ -30,7 +30,7 @@
 import {
   EVAL_FNS,
   type Expr,
-  FUNCTIONS,
+  SHADOWABLE_FNS,
   builtinFn,
   evaluate,
   freeVars,
@@ -41,7 +41,7 @@ import {
   substVars,
 } from './expr.ts';
 import { usesComplex } from './complex.ts';
-import { type GetFn, RESERVED, type ResolveOpts, resolveExpr } from './defs.ts';
+import { type GetFn, RESERVED, type ResolveOpts, nameable, resolveExpr } from './defs.ts';
 import { quadrature } from './integrate.ts';
 
 // --- base distributions ---
@@ -317,7 +317,7 @@ export function scanRandomRows(texts: readonly (string | null)[]): {
     }
     const m = CONST_ROW_RE.exec(text);
     // The name must be claimable as a definition (`e = X` stays an equation).
-    if (m && !FUNCTIONS.has(m[1]) && !RESERVED.has(m[1]) && !m[1].startsWith('u_')) {
+    if (m && nameable(m[1])) {
       candidates.set(i, { name: m[1], rhs: m[2] });
     }
   });
@@ -1523,7 +1523,10 @@ export function buildRVSystem(sys: RVSystem, scan: ReturnType<typeof scanRandomR
 
   const claim = (i: number, name: string): boolean => {
     rowRV.set(i, name);
-    if (RESERVED.has(name) || builtinFn(name)) {
+    // Late-addition builtins (gamma, sinc, …) stay claimable: a graph saved
+    // before they existed may use one as a random variable name.
+    const builtin = builtinFn(name);
+    if (RESERVED.has(name) || (builtin && !SHADOWABLE_FNS.has(builtin))) {
       errors.set(i, `Cannot use ${name} as a random variable name.`);
     } else if (sys.has(name) || opts.taken(name)) {
       errors.set(i, `${name} is already defined.`);

--- a/lib/expr.test.ts
+++ b/lib/expr.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { evaluate, Expr, freeVars, ISPRIME_MAX, parseExpr } from './expr.ts';
-import { toGLSL } from './glsl.ts';
+import { evaluate, Expr, freeVars, ISPRIME_MAX, LANCZOS, parseExpr } from './expr.ts';
+import { GLSL_PRELUDE, toGLSL } from './glsl.ts';
 
 function evalExpr(e: Expr, env: Record<string, number>): number {
   switch (e.kind) {
@@ -204,6 +204,26 @@ describe('factorial and special functions', () => {
     expect(toGLSL(parseExpr('x!'))).toBe('eq_factorial(x)');
     expect(toGLSL(parseExpr('sinc(x)'))).toBe('eq_sinc(x)');
     expect(toGLSL(parseExpr('coth(x)'))).toBe('eq_coth(x)');
+  });
+
+  it('feeds the one LANCZOS array into the GLSL prelude', () => {
+    for (const c of LANCZOS) expect(GLSL_PRELUDE).toContain(`+ ${c} / (z + `);
+  });
+
+  it('rejects != instead of reading it as postfix factorial', () => {
+    expect(() => parseExpr('x != 2')).toThrow(/!=/);
+    expect(() => parseExpr('x!=2')).toThrow(/!=/);
+    expect(ev('x! = 2', { x: 3 })).toBe(4); // spaced: the equation x! = 2, as l - r
+  });
+
+  it('stays finite up to the true double overflow (log-space Lanczos)', () => {
+    expect(ev('gamma(150)') / ev('149!')).toBeCloseTo(1, 9);
+    expect(ev('gamma(171)') / ev('170!')).toBeCloseTo(1, 9);
+    expect(ev('gamma(172)')).toBe(Infinity); // 171! really is beyond a double
+    expect(ev('169.5!')).toBeLessThan(Infinity);
+    // Reflection stays finite too: Γ(x)Γ(1−x) = π/sin(πx) deep in the negatives.
+    expect(Math.abs(ev('gamma(-142.7)'))).toBeGreaterThan(0);
+    expect(ev('gamma(-142.7) gamma(143.7)')).toBeCloseTo(Math.PI / Math.sin(-142.7 * Math.PI), 6);
   });
 });
 

--- a/lib/expr.test.ts
+++ b/lib/expr.test.ts
@@ -162,6 +162,51 @@ describe('toGLSL', () => {
   });
 });
 
+describe('factorial and special functions', () => {
+  const ev = (s: string, env: Record<string, number> = {}) => evaluate(parseExpr(s), env);
+
+  it('evaluates postfix factorial exactly on whole numbers', () => {
+    expect(ev('5!')).toBe(120);
+    expect(ev('0!')).toBe(1);
+    expect(ev('3!!')).toBe(720);
+    expect(ev('170!')).toBe(7.257415615307994e306);
+    expect(ev('171!')).toBe(Infinity);
+  });
+
+  it('binds tighter than ^ and unary minus, and ends a value', () => {
+    expect(ev('2^3!')).toBe(64);
+    expect(ev('-3!')).toBe(-6);
+    expect(ev('3! x', { x: 2 })).toBe(12); // implicit multiplication after !
+    expect(ev('3!(x + 1)', { x: 1 })).toBe(12);
+  });
+
+  it('extends to the reals through Gamma, undefined at the poles', () => {
+    expect(ev('gamma(5)')).toBeCloseTo(24, 9);
+    // Lanczos g=5 is documented to ~2e-10 relative error; hold it to that.
+    expect(ev('gamma(0.5)')).toBeCloseTo(Math.sqrt(Math.PI), 9);
+    expect(ev('gamma(-0.5)')).toBeCloseTo(-2 * Math.sqrt(Math.PI), 9);
+    expect(ev('(0.5)!')).toBeCloseTo(0.5 * Math.sqrt(Math.PI), 9);
+    expect(ev('Gamma(4)')).toBeCloseTo(6, 9); // case-folded like other builtins
+    expect(ev('gamma(0)')).toBeNaN();
+    expect(ev('gamma(-3)')).toBeNaN();
+    expect(ev('(-1)!')).toBeNaN();
+  });
+
+  it('evaluates sinc and coth', () => {
+    expect(ev('sinc(0)')).toBe(1);
+    expect(ev('sinc(pi)')).toBeCloseTo(0, 12);
+    expect(ev('sinc(1.5)')).toBeCloseTo(Math.sin(1.5) / 1.5, 12);
+    expect(ev('coth(1)')).toBeCloseTo(1 / Math.tanh(1), 12);
+  });
+
+  it('compiles to the GLSL twins', () => {
+    expect(toGLSL(parseExpr('gamma(x)'))).toBe('eq_gamma(x)');
+    expect(toGLSL(parseExpr('x!'))).toBe('eq_factorial(x)');
+    expect(toGLSL(parseExpr('sinc(x)'))).toBe('eq_sinc(x)');
+    expect(toGLSL(parseExpr('coth(x)'))).toBe('eq_coth(x)');
+  });
+});
+
 describe('negative base with fractional exponent (real odd roots)', () => {
   const ev = (s: string, env: Record<string, number> = {}) => evaluate(parseExpr(s), env);
 

--- a/lib/expr.ts
+++ b/lib/expr.ts
@@ -36,7 +36,7 @@ export const FUNCTIONS = new Set([
   'sqrt', 'abs', 'exp', 'ln', 'log', 'floor', 'ceil', 'round',
   'min', 'max', 'mod', 'sign', 'fract',
   'erf', 'normalpdf', 'normalcdf',
-  'gcd', 'isprime',
+  'gcd', 'isprime', 'gamma', 'factorial', 'sinc', 'coth',
   're', 'im', 'arg', 'conj',
   // Point (2D vector) helpers and geometry statements, lowered symbolically
   // by lowerGeom before anything evaluates or compiles them.
@@ -229,6 +229,10 @@ const ops = operators<PNode>({
 
   '^': BinaryRightInfix<PNode>((a, b): PNode => bin('^')(asVecOrExpr(a), asVecOrExpr(b))),
 
+  // Postfix factorial: declared after '^' so 2^3! parses as 2^(3!), and
+  // [neg] (sharing '^'s level) stays below it: -x! is -(x!).
+  '!': Postfix<PNode>((a): Expr => ({ kind: 'call', name: 'factorial', args: [asExpr(a)] })),
+
   // Function application: binds tighter than '^' so sin(x)^2 means (sin(x))^2.
   '[apply]': BinaryInfix<PNode>((a, b): Expr => {
     if (a?.kind !== 'var' || !isFnName(a.name)) throw new Error('Expected a function name.');
@@ -357,7 +361,9 @@ function *addImplicitTokens(bare: Iterable<Token>): Iterable<Token> {
   for (const token of bare) {
     if (token.type === 'whitespace') continue;
 
-    const afterValue = last !== null && (last.type === 'number' || last.type === 'symbol' || last.type === 'parenclose');
+    // Postfix '!' ends a value, so 5!x and 3!(x+1) multiply implicitly.
+    const afterValue = last !== null && (last.type === 'number' || last.type === 'symbol'
+      || last.type === 'parenclose' || (last.type === 'operator' && last.str === '!'));
 
     if (token.type === 'bar') {
       // |x| is abs(x): a bar after a value closes the innermost open bar;
@@ -528,6 +534,42 @@ export function realPow(a: number, b: number): number {
   return NaN; // no small-denominator rational found: irrational-looking exponent
 }
 
+/** Lanczos coefficients (g = 5, n = 6): relative error < 2e-10 over the reals. */
+const LANCZOS = [
+  76.18009172947146, -86.50532032941677, 24.01409824083091,
+  -1.231739572450155, 0.1208650973866179e-2, -0.5395239384953e-5,
+];
+
+/**
+ * Real Γ(x). Poles at 0, −1, −2, … evaluate to NaN; other negative reals go
+ * through the reflection formula Γ(x)Γ(1−x) = π/sin(πx). Overflows to
+ * Infinity above x ≈ 171.62, like the rest of double arithmetic.
+ *
+ * Kept in sync with the eq_gamma() GLSL twin in glsl.ts (same Lanczos
+ * coefficients and reflection, minus the exact-pole check float32 can't do).
+ */
+export function gammaFn(x: number): number {
+  if (x < 0.5) {
+    if (Number.isInteger(x)) return NaN; // pole
+    return Math.PI / (Math.sin(Math.PI * x) * gammaFn(1 - x));
+  }
+  const z = x - 1;
+  let ser = 1.000000000190015;
+  for (let i = 0; i < LANCZOS.length; i++) ser += LANCZOS[i] / (z + i + 1);
+  const t = z + 5.5;
+  return Math.sqrt(2 * Math.PI) * Math.pow(t, z + 0.5) * Math.exp(-t) * ser;
+}
+
+/** x! = Γ(x + 1), except exact for the whole numbers a double can hold. */
+export function factorialFn(x: number): number {
+  if (Number.isInteger(x) && x >= 0 && x <= 170) {
+    let r = 1;
+    for (let k = 2; k <= x; k++) r *= k;
+    return r;
+  }
+  return gammaFn(x + 1);
+}
+
 export const EVAL_FNS: Record<string, (...xs: number[]) => number> = {
   sin: Math.sin, cos: Math.cos, tan: Math.tan,
   asin: Math.asin, acos: Math.acos, atan: Math.atan, atan2: Math.atan2,
@@ -556,6 +598,10 @@ export const EVAL_FNS: Record<string, (...xs: number[]) => number> = {
     for (let i = 2; i * i <= n; i++) if (n % i === 0) return 0;
     return 1;
   },
+  gamma: gammaFn,
+  factorial: factorialFn,
+  sinc: x => (x === 0 ? 1 : Math.sin(x) / x),
+  coth: x => 1 / Math.tanh(x),
 };
 
 /** Numerically evaluate a scalar expression with the given variable bindings. */

--- a/lib/expr.ts
+++ b/lib/expr.ts
@@ -53,6 +53,13 @@ export const FUNCTIONS = new Set([
 ]);
 
 /**
+ * Builtins added after graphs existed in the wild: a definition or random
+ * variable may claim these names, shadowing the builtin, so a saved graph
+ * that defines its own `gamma(x) = …` or `sinc = …` keeps its meaning.
+ */
+export const SHADOWABLE_FNS: ReadonlySet<string> = new Set(['gamma', 'factorial', 'sinc', 'coth']);
+
+/**
  * Flatten a (possibly chained) inequality into its comparisons; comparison k
  * compares the previous comparison's right side, so 0 < y < x yields
  * [0 < y, y < x].
@@ -203,6 +210,13 @@ const ops = operators<PNode>({
   }),
 
   ':': BinaryInfix<PNode>((a, b): PNode => ({ kind: 'pcase', cond: asExpr(a), value: asExpr(b) })),
+
+  // Recognized as one token so it never half-matches as postfix '!' followed
+  // by '=' — x != 2 would silently graph factorial(x) = 2. There is no ≠
+  // relation to plot, so it only explains itself.
+  '!=': BinaryInfix<PNode>((): PNode => {
+    throw new Error("'!=' is not supported — for a factorial equation, put a space before '=': x! = 2.");
+  }),
 
   '<': asIneq('<'),
   '<=': asIneq('<='),
@@ -361,9 +375,11 @@ function *addImplicitTokens(bare: Iterable<Token>): Iterable<Token> {
   for (const token of bare) {
     if (token.type === 'whitespace') continue;
 
-    // Postfix '!' ends a value, so 5!x and 3!(x+1) multiply implicitly.
+    // A postfix operator (per the ops table: '!') ends a value, so 5!x and
+    // 3!(x+1) multiply implicitly.
+    const afterPostfix = last?.type === 'operator' && ops[last.str]?.n === 1 && !ops[last.str].right;
     const afterValue = last !== null && (last.type === 'number' || last.type === 'symbol'
-      || last.type === 'parenclose' || (last.type === 'operator' && last.str === '!'));
+      || last.type === 'parenclose' || afterPostfix);
 
     if (token.type === 'bar') {
       // |x| is abs(x): a bar after a value closes the innermost open bar;
@@ -534,8 +550,10 @@ export function realPow(a: number, b: number): number {
   return NaN; // no small-denominator rational found: irrational-looking exponent
 }
 
-/** Lanczos coefficients (g = 5, n = 6): relative error < 2e-10 over the reals. */
-const LANCZOS = [
+/** Lanczos coefficients (g = 5, n = 6): relative error < 2e-10 over the
+ *  reals. Interpolated into the eq_gamma() GLSL twin (glsl.ts) too, so both
+ *  implementations share this one array. */
+export const LANCZOS = [
   76.18009172947146, -86.50532032941677, 24.01409824083091,
   -1.231739572450155, 0.1208650973866179e-2, -0.5395239384953e-5,
 ];
@@ -557,18 +575,26 @@ export function gammaFn(x: number): number {
   let ser = 1.000000000190015;
   for (let i = 0; i < LANCZOS.length; i++) ser += LANCZOS[i] / (z + i + 1);
   const t = z + 5.5;
-  return Math.sqrt(2 * Math.PI) * Math.pow(t, z + 0.5) * Math.exp(-t) * ser;
+  // Assembled in log space: a bare pow(t, z + 0.5) factor overflows a double
+  // from x ≈ 143, well before Γ itself does.
+  return Math.exp((z + 0.5) * Math.log(t) - t + Math.log(2.5066282746310002 * ser));
 }
+
+/** k! for k = 0..170, every factorial a double can hold. */
+const FACTORIALS = new Float64Array(171);
+FACTORIALS[0] = 1;
+for (let k = 1; k < FACTORIALS.length; k++) FACTORIALS[k] = FACTORIALS[k - 1] * k;
 
 /** x! = Γ(x + 1), except exact for the whole numbers a double can hold. */
 export function factorialFn(x: number): number {
-  if (Number.isInteger(x) && x >= 0 && x <= 170) {
-    let r = 1;
-    for (let k = 2; k <= x; k++) r *= k;
-    return r;
-  }
+  if (Number.isInteger(x) && x >= 0 && x <= 170) return FACTORIALS[x];
   return gammaFn(x + 1);
 }
+
+/** sin(x)/x with the removable hole filled: sinc(0) = 1. */
+export const sincFn = (x: number): number => (x === 0 ? 1 : Math.sin(x) / x);
+
+export const cothFn = (x: number): number => 1 / Math.tanh(x);
 
 export const EVAL_FNS: Record<string, (...xs: number[]) => number> = {
   sin: Math.sin, cos: Math.cos, tan: Math.tan,
@@ -600,8 +626,8 @@ export const EVAL_FNS: Record<string, (...xs: number[]) => number> = {
   },
   gamma: gammaFn,
   factorial: factorialFn,
-  sinc: x => (x === 0 ? 1 : Math.sin(x) / x),
-  coth: x => 1 / Math.tanh(x),
+  sinc: sincFn,
+  coth: cothFn,
 };
 
 /** Numerically evaluate a scalar expression with the given variable bindings. */

--- a/lib/glsl.ts
+++ b/lib/glsl.ts
@@ -18,6 +18,10 @@ export const FN_GLSL: Record<string, string> = {
   normalcdf: 'eq_normalcdf',
   gcd: 'eq_gcd',
   isprime: 'eq_isprime',
+  gamma: 'eq_gamma',
+  factorial: 'eq_factorial',
+  sinc: 'eq_sinc',
+  coth: 'eq_coth',
 };
 
 /** Helper functions some expressions need; prepend once to the shader. */
@@ -63,6 +67,27 @@ float eq_isprime(float x) {
   }
   return 1.0;
 }
+float eq_gamma(float x) {
+  // Lanczos g=5 like gammaFn() in expr.ts, with the x < 0.5 reflection
+  // inlined (GLSL has no recursion). float32 can't hit the negative-integer
+  // poles exactly, so they render as the divergence they neighbor.
+  float z = x < 0.5 ? 1.0 - x : x;
+  z -= 1.0;
+  float ser = 1.000000000190015
+    + 76.18009172947146 / (z + 1.0)
+    - 86.50532032941677 / (z + 2.0)
+    + 24.01409824083091 / (z + 3.0)
+    - 1.231739572450155 / (z + 4.0)
+    + 0.001208650973866179 / (z + 5.0)
+    - 0.000005395239384953 / (z + 6.0);
+  float t = z + 5.5;
+  float g = 2.5066282746310002 * pow(t, z + 0.5) * exp(-t) * ser;
+  if (x >= 0.5) return g;
+  return 3.141592653589793 / (sin(3.141592653589793 * x) * g);
+}
+float eq_factorial(float x) { return eq_gamma(x + 1.0); }
+float eq_sinc(float x) { return x == 0.0 ? 1.0 : sin(x) / x; }
+float eq_coth(float x) { return cosh(x) / sinh(x); }
 float eq_pow(float a, float b) {
   // Support negative bases via the "real odd root" convention, e.g.
   // (-8)^(1/3) = -2, matching graphing calculators like Desmos. For a < 0,

--- a/lib/glsl.ts
+++ b/lib/glsl.ts
@@ -4,7 +4,7 @@
  * An equation l = r compiles to the scalar field F = l - r; the graph is the
  * zero set of F, which the renderers extract in a fragment shader.
  */
-import { type Expr, ISPRIME_MAX, ineqComparisons } from './expr.ts';
+import { type Expr, ISPRIME_MAX, LANCZOS, ineqComparisons } from './expr.ts';
 
 export const FN_GLSL: Record<string, string> = {
   ln: 'log',
@@ -68,26 +68,26 @@ float eq_isprime(float x) {
   return 1.0;
 }
 float eq_gamma(float x) {
-  // Lanczos g=5 like gammaFn() in expr.ts, with the x < 0.5 reflection
-  // inlined (GLSL has no recursion). float32 can't hit the negative-integer
-  // poles exactly, so they render as the divergence they neighbor.
+  // Lanczos g=5 — the coefficients interpolate from LANCZOS in expr.ts, the
+  // gammaFn() twin — with the x < 0.5 reflection inlined (GLSL has no
+  // recursion). float32 can't hit the negative-integer poles exactly, so
+  // they render as the divergence they neighbor.
   float z = x < 0.5 ? 1.0 - x : x;
   z -= 1.0;
   float ser = 1.000000000190015
-    + 76.18009172947146 / (z + 1.0)
-    - 86.50532032941677 / (z + 2.0)
-    + 24.01409824083091 / (z + 3.0)
-    - 1.231739572450155 / (z + 4.0)
-    + 0.001208650973866179 / (z + 5.0)
-    - 0.000005395239384953 / (z + 6.0);
+${LANCZOS.map((c, i) => `    + ${c} / (z + ${i + 1}.0)`).join('\n')};
   float t = z + 5.5;
-  float g = 2.5066282746310002 * pow(t, z + 0.5) * exp(-t) * ser;
+  // Assembled in log space: a bare pow(t, z + 0.5) factor overflows float32
+  // from x ≈ 27, well before Γ itself does (~35).
+  float g = exp((z + 0.5) * log(t) - t + log(2.5066282746310002 * ser));
   if (x >= 0.5) return g;
   return 3.141592653589793 / (sin(3.141592653589793 * x) * g);
 }
 float eq_factorial(float x) { return eq_gamma(x + 1.0); }
 float eq_sinc(float x) { return x == 0.0 ? 1.0 : sin(x) / x; }
-float eq_coth(float x) { return cosh(x) / sinh(x); }
+// 1/tanh, not cosh/sinh: the latter is Inf/Inf = NaN for |x| > ~89 where
+// coth is ±1 (and the cothFn() CPU twin says so).
+float eq_coth(float x) { return 1.0 / tanh(x); }
 float eq_pow(float a, float b) {
   // Support negative bases via the "real odd root" convention, e.g.
   // (-8)^(1/3) = -2, matching graphing calculators like Desmos. For a < 0,

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -91,12 +91,14 @@ demand instead of living in a tool description. No authentication required.
   implicit: `2x`, `x y`, `2cos(t)`, `a(x-1)` all work.
 - Absolute value bars: `|x|`, including nested/multiplied forms like `2|x-1|`.
 - Constants: `pi`, `tau`, `e`. Imaginary unit `i` in complex expressions.
-- Functions: sin cos tan asin acos atan atan2(y,x) sinh cosh tanh sech asinh
-  acosh atanh sqrt abs exp ln (natural) log (base 10) floor ceil round min max
-  mod sign fract, complex helpers re im arg conj, and point helpers
-  dot cross perp midpoint unit. Function names are
+- Functions: sin cos tan asin acos atan atan2(y,x) sinh cosh tanh sech coth
+  asinh acosh atanh sqrt abs exp ln (natural) log (base 10) floor ceil round
+  min max mod sign fract sinc gamma factorial, complex helpers re im arg conj,
+  and point helpers dot cross perp midpoint unit. Function names are
   case-insensitive: `Sin(x)`, `SQRT(x)` and `sin(x)` are the same call. Always
   use parentheses for arguments — write `sin(x)`, not `sin x`.
+- Factorial: postfix `!` — `5!` is 120, `x!` plots as Γ(x+1), `2^3!` is 2^6.
+  Non-integers use the Gamma function; negative integers are undefined.
 - Derivatives: `d/dx (x^3)` differentiates symbolically; higher order
   `d^2/dx^2 (...)`; works for any single-letter variable, e.g. `d/dq (q^2)`.
 - Sums and products: `sum(n=1..N, sin(n x)/n)` and `prod(k=1..N, k)`, also

--- a/worker/vm.test.ts
+++ b/worker/vm.test.ts
@@ -22,6 +22,15 @@ describe('expression stack machine', () => {
     }
   });
 
+  it('matches the AST evaluator on the special functions', () => {
+    const e = parseExpr('x! + gamma(x + 3) + sinc(x) + coth(x)');
+    const prog = compileProg(e, new Map([['x', 0]]));
+    const stack = new Float64Array(prog.depth);
+    for (const x of [2.5, 0.3, -0.7]) {
+      expect(run(prog, [x], stack)).toBeCloseTo(evaluate(e, { x }), 12);
+    }
+  });
+
   it('matches the AST evaluator on negative bases with fractional exponents', () => {
     const e = parseExpr('x^(1/3)');
     const prog = compileProg(e, new Map([['x', 0]]));

--- a/worker/vm.ts
+++ b/worker/vm.ts
@@ -5,7 +5,7 @@
  * sample is too slow and Workers forbid dynamic codegen (`new Function`), so
  * expressions compile once to opcode arrays run by a small stack machine.
  */
-import { type Expr, erf, ineqComparisons, normalcdf, normalpdf, realPow } from '../lib/expr.ts';
+import { type Expr, erf, factorialFn, gammaFn, ineqComparisons, normalcdf, normalpdf, realPow } from '../lib/expr.ts';
 
 const enum Op { Const, Var, Add, Sub, Mul, Div, Pow, Neg, Fn1, Fn2, Fn3, Lt, Le, Gt, Ge, Sel }
 
@@ -20,6 +20,9 @@ const FN1: Record<string, (x: number) => number> = {
   fract: x => x - Math.floor(x),
   re: x => x, im: () => 0, arg: x => (x < 0 ? Math.PI : 0), conj: x => x,
   erf,
+  gamma: gammaFn, factorial: factorialFn,
+  sinc: x => (x === 0 ? 1 : Math.sin(x) / x),
+  coth: x => 1 / Math.tanh(x),
 };
 
 const FN2: Record<string, (a: number, b: number) => number> = {

--- a/worker/vm.ts
+++ b/worker/vm.ts
@@ -5,7 +5,7 @@
  * sample is too slow and Workers forbid dynamic codegen (`new Function`), so
  * expressions compile once to opcode arrays run by a small stack machine.
  */
-import { type Expr, erf, factorialFn, gammaFn, ineqComparisons, normalcdf, normalpdf, realPow } from '../lib/expr.ts';
+import { type Expr, cothFn, erf, factorialFn, gammaFn, ineqComparisons, normalcdf, normalpdf, realPow, sincFn } from '../lib/expr.ts';
 
 const enum Op { Const, Var, Add, Sub, Mul, Div, Pow, Neg, Fn1, Fn2, Fn3, Lt, Le, Gt, Ge, Sel }
 
@@ -20,9 +20,7 @@ const FN1: Record<string, (x: number) => number> = {
   fract: x => x - Math.floor(x),
   re: x => x, im: () => 0, arg: x => (x < 0 ? Math.PI : 0), conj: x => x,
   erf,
-  gamma: gammaFn, factorial: factorialFn,
-  sinc: x => (x === 0 ? 1 : Math.sin(x) / x),
-  coth: x => 1 / Math.tanh(x),
+  gamma: gammaFn, factorial: factorialFn, sinc: sincFn, coth: cothFn,
 };
 
 const FN2: Record<string, (a: number, b: number) => number> = {


### PR DESCRIPTION
## What

Closes the last *mathematical* parity gap against legacy graph.tk (per the parity pass): the special-functions basket.

- **`gamma(x)`** — Lanczos g=5 (~2e-10 relative error), reflection formula for negative reals, NaN at the poles. Case-folded like every builtin, so `Gamma(x)` works.
- **Postfix `!`** — `5!` = 120 (exact integer arithmetic up to 170!), `x!` plots as Γ(x+1), non-integer and negative-non-integer arguments included. Binds tighter than `^` (`2^3!` = 2^(3!) = 64), tighter than unary minus (`-3!` = −6), and ends a value for implicit multiplication (`5!x`, `3!(x+1)`). `factorial(x)` also works as a named call.
- **`sinc(x)`** (sin x/x, 1 at 0) and **`coth(x)`**, both with symbolic derivatives in diff.ts; gamma deliberately falls through to the finite-difference fallback (digamma isn't in the language).
- GLSL twins (`eq_gamma` etc., same Lanczos coefficients) so curves render on the GPU; worker VM entries so og previews and MCP validation agree; llms.txt documents the new names and the `!` syntax.

**Deferred by design**: `sum[n=1..inf]` stays unsupported — doing it honestly means symbolic limit computation, not a numeric partial-sum guess (per discussion; noted in the parity memory). ζ/Lambert W/Bell also left out as deep cuts nobody has asked for.

## Test plan

- [x] 637 tests pass, including new parse/precedence/pole/accuracy cases and a VM-vs-evaluator parity test
- [x] Typecheck clean on all three tsconfigs
- [x] Verified in-browser: `y = gamma(x)` draws the textbook curve (minimum ≈0.886 at x≈1.46, alternating lobes between negative poles), `y = x!` is the same curve shifted one left, sinc oscillates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)